### PR TITLE
Report serviceLost events.

### DIFF
--- a/src/zeroconf.android.ts
+++ b/src/zeroconf.android.ts
@@ -55,7 +55,12 @@ export class Zeroconf extends Common {
           // console.log(`Finished resolving for device ${serviceInfo.getServiceName()}...`);
         });
       },
-      onServiceLost: (serviceInfo: android.net.nsd.NsdServiceInfo) => {}
+      onServiceLost: (serviceInfo: android.net.nsd.NsdServiceInfo) => {
+          this.onServiceLost({
+              'name': serviceInfo.getServiceName(),
+              'type': serviceInfo.getServiceType(),
+          });
+      }
     });
 
     this.mNsdManager.discoverServices(this.serviceType, this.NsdManager.PROTOCOL_DNS_SD, this.mDiscoveryListener);

--- a/src/zeroconf.common.ts
+++ b/src/zeroconf.common.ts
@@ -15,6 +15,10 @@ export class Common extends Observable {
   protected onServiceFound(service:any) : void {
     this.notifyPropertyChange('serviceFound', service);
   }
+
+  protected onServiceLost(service:any) : void {
+    this.notifyPropertyChange('serviceLost', service);
+  }
 }
 
 export interface ZeroconfService {


### PR DESCRIPTION
Hey there... this PR wires up the serviceLost events in Android and iOS.

It also fixes an issue I was seeing on iOS related to NativeScript. Basically, the first time the MyNSNetServiceBrowserDelegate was called was fine, but then subsequent calls would happen with an invalid "this". Instead of being the original, "this" would be an empty object - {}. While debugging I added that singleton global ref to see what was happening and that fixed things. I'm a newbie to NativeScript so I'm not sure what the underlying issue was/is.